### PR TITLE
Allow HTTPS stack to connect to servers with self-signed certificates

### DIFF
--- a/whip.go
+++ b/whip.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"crypto/tls"
 
 	"github.com/pion/mediadevices"
 	"github.com/pion/webrtc/v3"
@@ -86,7 +87,13 @@ func (whip *WHIPClient) Publish() {
 
 	// log.Println(offer.SDP)
 	var sdp = []byte(offer.SDP)
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 	req, err := http.NewRequest("POST", whip.endpoint, bytes.NewBuffer(sdp))
 	if err != nil {
 		log.Fatal("Unexpected error building http request. ", err)


### PR DESCRIPTION
As the title says, this allows the stack to connect to HTTPS servers with self-signed certificates, where it would previously fail with an error:

    x509: certificate is not valid for any names, but wanted to match localhost

I'm not a Go developer, so this might not be the best way to do this, but it seems to do the trick. This could also be made configurable via command line, I guess (in case people do want validation to be enforced), but since I assume this is mostly a prototype it should be ok.