### PR TITLE
Fix authorization header on DELETE

### DIFF
--- a/whip.go
+++ b/whip.go
@@ -133,7 +133,9 @@ func (whip *WHIPClient) Close(skipTlsAuth bool) {
 	if err != nil {
 		log.Fatal("Unexpected error building http request. ", err)
 	}
-	req.Header.Add("Authorization", "Bearer "+whip.token)
+	if whip.token != "" {
+		req.Header.Add("Authorization", "Bearer "+whip.token)
+	}
 
 	client := &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
This was causing an invalid `Authorization: Bearer `to be sent if no token was specified.