### PR TITLE
Support redirects on WHIP client

### DIFF
--- a/whip.go
+++ b/whip.go
@@ -83,6 +83,10 @@ func (whip *WHIPClient) Publish(stream mediadevices.MediaStream, mediaEngine web
 				InsecureSkipVerify: skipTlsAuth,
 			},
 		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			req.Header.Add("Authorization", "Bearer "+whip.token)
+			return nil
+		},
 	}
 	req, err := http.NewRequest("POST", whip.endpoint, bytes.NewBuffer(sdp))
 	if err != nil {

--- a/whip.go
+++ b/whip.go
@@ -84,7 +84,7 @@ func (whip *WHIPClient) Publish(stream mediadevices.MediaStream, mediaEngine web
 			},
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			req.Header.Add("Authorization", "Bearer "+whip.token)
+			req.Header.Set("Authorization", "Bearer "+whip.token)
 			return nil
 		},
 	}

--- a/whip.go
+++ b/whip.go
@@ -84,6 +84,10 @@ func (whip *WHIPClient) Publish(stream mediadevices.MediaStream, mediaEngine web
 			},
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			const MaxRedirectDepth = 10
+			if len(via) >= MaxRedirectDepth {
+				return fmt.Errorf("redirect limit exceeded: %d", MaxRedirectDepth)
+			}
 			req.Header.Set("Authorization", "Bearer "+whip.token)
 			return nil
 		},


### PR DESCRIPTION
Add whip token to redirects (required for publishing to Amazon IVS)